### PR TITLE
Improving User Parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ app.post('/new-message', (req, res) => {
           clearUsernames(message, chatId, ref, res);
         }
       } else if (message.new_chat_participant || message.left_chat_participant) {
-        addOrRemoveParticipant(message, chatId, usernames, ref, res);
+        return addOrRemoveParticipant(message, chatId, usernames, ref, res);
       }
     }, error => {
       console.log('Error reading db:', error);
@@ -164,6 +164,12 @@ const clearUsernames = (message, chatId, ref, res) => {
 };
 
 const addOrRemoveParticipant = (message, chatId, usernames, ref, res) => {
+  const isValid = (message.new_chat_participant && message.new_chat_participant.username)
+    || (message.left_chat_participant && message.left_chat_participant.username);
+  
+  if (!isValid)
+    return res.end('Undefined username');
+
   ref.set({
     'usernames': messageManager.extractUniqueUsernames(message, usernames),
   });
@@ -173,9 +179,9 @@ const addOrRemoveParticipant = (message, chatId, usernames, ref, res) => {
     `${message.left_chat_participant.username} was removed from the list.`;
 
   telegramManager.talkToBot(chatId, msg).then(() => {
-    res.end(msg);
+    return res.end(msg);
   }, err => {
     console.log(err);
-    res.end('Error: ', err);
+    return res.end('Error: ', err);
   });
 };

--- a/messageManager.js
+++ b/messageManager.js
@@ -1,41 +1,26 @@
-const botRelatedUserNames = ['/set', 'pingchannelbot'];
-const stripOutBotRelatedUserNames = usernames => {
-    return usernames.filter(u => botRelatedUserNames.indexOf(u) === -1);
-};
-
 const extractValidUsernames = usernames => {
-    const users = usernames.split(/(\s+)|@/g).filter(u => !!u)
-        .filter(u => u.trim() !== '');
-
-    const validUsernames = stripOutBotRelatedUserNames(users);
-    return validUsernames.map(v => `@${v}`.toLocaleLowerCase());
+    var matches = usernames.match(/@[^\s|@]*/g);
+    return matches ? matches.filter(u => u !== '@pingchannelbot') : [];
 };
 
-const removeUsername = (usernames, user) => {
-    const users = usernames.split(/(\s+)|@/g)
-        .filter(u => !!u)
-        .filter(u => u.trim() !== '')
-        .filter(u => u.indexOf(user.toLocaleLowerCase()) === -1);
-
-    return users.map(v => `@${v}`.toLocaleLowerCase());
-};
-
-const joinUsernames = usernames => {
-    return usernames.size > 0 ? [...usernames].join(' ') : 'No usernames added.';
-};
+const joinUsernames = usernames => usernames.size > 0
+    ? [...usernames].join(' ')
+    : 'No usernames added.';
 
 const extractUniqueUsernames = (message, usernames) => {
     if (message.new_chat_participant) {
-        usernames += ' ' + message.new_chat_participant.username;
+        if(message.new_chat_participant.username)
+            usernames += ` @${message.new_chat_participant.username}`;
     } else if (message.text) {
         usernames += ' ' + message.text;
     }
 
-    let users = [];
+    let users = extractValidUsernames(usernames);
+
     if (message.left_chat_participant) {
-        users = removeUsername(usernames, message.left_chat_participant.username);
-    } else {
-        users = extractValidUsernames(usernames);
+        if(message.left_chat_participant.username) {
+            users = users.filter(u => u !== `@${message.left_chat_participant.username}`);
+        }
     }
 
     if (users.length > 0)

--- a/messageManager.js
+++ b/messageManager.js
@@ -1,5 +1,5 @@
 const extractValidUsernames = usernames => {
-    var matches = usernames.match(/@[^\s|@]*/g);
+    const matches = usernames.match(/@[^\s|@]*/g);
     return matches ? matches.filter(u => u !== '@pingchannelbot') : [];
 };
 

--- a/test.js
+++ b/test.js
@@ -20,22 +20,72 @@ describe('message manager', () => {
   beforeEach(() => {
     message.text = defaultText;
     message.entities = defaultEntities;
+    message.new_chat_participant = undefined;
+    message.left_chat_participant = undefined;
   });
 
   describe('extractUniqueUsernames', () => {
     it('can extract 1 username', () => {
-      let users = '';
       message.text = '/set@pingchannelbot @username';
-      const usernames = messageManager.extractUniqueUsernames(message, users);
+      const usernames = messageManager.extractUniqueUsernames(message, '');
 
       assert.strictEqual('@username', usernames);
     });
 
     it('gets usernames as string', () => {
-      let users = 'username';
+      let users = '@naz klk @lola maria laba 24123ffsdf @winner32 @willy-ovalle @carlos@marcos';
       const usernames = messageManager.extractUniqueUsernames(message, users);
 
-      assert.strictEqual('@username @username1', usernames);
+      assert.strictEqual('@naz @lola @winner32 @willy-ovalle @carlos @marcos @username @username1', usernames);
+    });
+
+    describe('new_chat_participant', () => {
+      it('adds new member', () => {
+        message.new_chat_participant = {
+          username: 'newuser'
+        };
+
+        const usernames = messageManager.extractUniqueUsernames(message, '');
+
+        assert.strictEqual('@newuser', usernames);
+      });
+
+      it('ignores new member with undefined usernames', () => {
+        var users = '@username';
+        message.new_chat_participant = {
+          username: undefined
+        };
+
+        const usernames = messageManager.extractUniqueUsernames(message, users);
+
+        assert.strictEqual(users, usernames);
+      });
+    });
+
+    describe('left_chat_participant', () => {
+      it('removes member', () => {
+        var users = '@existing @new';
+        message.text = undefined;
+        message.left_chat_participant = {
+          username: 'existing'
+        };
+
+        const usernames = messageManager.extractUniqueUsernames(message, users);
+
+        assert.strictEqual('@new', usernames);
+      });
+
+      it('ignores undefined usernames', () => {
+        var users = '@existing @new';
+        message.text = undefined;
+        message.left_chat_participant = {
+          username: undefined
+        };
+
+        const usernames = messageManager.extractUniqueUsernames(message, users);
+
+        assert.strictEqual(users, usernames);
+      });
     });
   });
 


### PR DESCRIPTION
* Improve user parsing to match only users which begin with `@`  e.g.:  
`/set @naz klk @lola maria laba 24123ffsdf @winner32 @willy-ovalle @carlos@marcos`
will set the list to: `@naz @lola @winner32 @willy-ovalle @carlos @marcos`

* Users which have been added of removed to a group and have undefined usernames should not add `undefined` to the list.

